### PR TITLE
Fix publishing workflow action

### DIFF
--- a/.github/workflows/npm_publish.yaml
+++ b/.github/workflows/npm_publish.yaml
@@ -1,6 +1,7 @@
 name: npm publish
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 
@@ -26,6 +27,6 @@ jobs:
 
       - name: Publish npm package to both places
         run: |
-          yarn publish --access public
+          yarn npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
We need to use the yarn v3 publish command. I'm also enabling the publish workflow to be triggered manually, in case it needs to be done as a one-off sometimes