### PR TITLE
add the tabs and tabitem to the method component interface

### DIFF
--- a/src/Method/Method.tsx
+++ b/src/Method/Method.tsx
@@ -34,6 +34,8 @@ interface IProps {
   methodPlugins?: Array<React.FC<IMethodPluginProps>>;
   components?: {
     CodeBlock: React.FC<{children: string, className?: string}>;
+    Tabs?: React.FC<{children: any;}>;
+    TabItem?: React.FC<{children: any; label: string; value: string}>;
   };
   onExamplePairingChange?: (examplePairing: ExamplePairingObject | undefined) => void;
   reactJsonOptions?: object;


### PR DESCRIPTION
We had this in the patch, and it was forgotten in the customizations. Since this is an interface definition, the only thing this will change is the intellisense. I don't believe there is any real, functional change happening.